### PR TITLE
lib: skip comment lines when parsing the conf file

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -88,6 +88,7 @@ parse_file() {
 	local file="${1}"
 	if [ -f ${file} ]; then
 		while read cline; do
+            [[ "${cline}" =~ ^#.*$ ]] && continue
 			parse_string "${cline}"
 		done < ${file}
 	fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -88,7 +88,7 @@ parse_file() {
 	local file="${1}"
 	if [ -f ${file} ]; then
 		while read cline; do
-            [[ "${cline}" =~ ^#.*$ ]] && continue
+			[[ "${cline}" =~ ^#.*$ ]] && continue
 			parse_string "${cline}"
 		done < ${file}
 	fi


### PR DESCRIPTION
Ignore eventual comment lines in conf files.