### PR TITLE
Fix running sysusers.in without arguments

### DIFF
--- a/bin/sysusers.in
+++ b/bin/sysusers.in
@@ -65,7 +65,7 @@ while true; do
 			version=1
 			shift;
 			;;
-		--) args=("${@}"); shift; break;;
+		--) shift; args=("${@}"); break;;
 		*) break;;
 	esac
 done


### PR DESCRIPTION
The `if [ ${#args[@]} -eq 0 ]; then` codepath would never be taken as
getopt always added '--' to the argument list, increasing the argument
array length.